### PR TITLE
feat: add toaster for error and success cases

### DIFF
--- a/src/features/account/pages/AccountPage.jsx
+++ b/src/features/account/pages/AccountPage.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from "react";
 import style from "./AccountPage.module.css";
+import { Snackbar, Alert } from "@mui/material";
 import Button from "../../../components/Button/Button";
 import {
   updateAccount,
@@ -13,6 +14,7 @@ export default function AccountPage() {
   const [username, setUsername] = useState("");
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
+  const [snackbar, setSnackbar] = useState({ open: false, message: "", severity: "success" });
 
   const token = getToken(); // 🔹 busca token do localStorage
 
@@ -40,9 +42,16 @@ export default function AccountPage() {
     try {
       await updateAccount({ username, email, password }, token);
       setPassword("");
+      setSnackbar({ open: true, message: "Senha alterada com sucesso!", severity: "success" });
     } catch (err) {
       console.error(err);
+      setSnackbar({ open: true, message: "Erro ao alterar a senha.", severity: "error" });
     }
+  };
+
+  const handleCloseSnackbar = (event, reason) => {
+    if (reason === 'clickaway') return;
+    setSnackbar({ ...snackbar, open: false });
   };
 
   const handleDelete = async () => {
@@ -108,6 +117,17 @@ export default function AccountPage() {
           </button>
         </div>
       </div>
+
+      <Snackbar
+        open={snackbar.open}
+        autoHideDuration={4000}
+        onClose={handleCloseSnackbar}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+      >
+        <Alert onClose={handleCloseSnackbar} severity={snackbar.severity} sx={{ width: '100%', fontSize: '1rem', alignItems: 'center' }}>
+          {snackbar.message}
+        </Alert>
+      </Snackbar>
     </div>
   );
 }

--- a/src/features/auth/components/LoginForm/LoginForm.jsx
+++ b/src/features/auth/components/LoginForm/LoginForm.jsx
@@ -3,12 +3,13 @@ import { loginUser } from "../../services/authService";
 import { saveToken } from "../../services/tokenService";
 import { useNavigate } from "react-router-dom";
 import { useState } from "react";
-import { LinearProgress } from "@mui/material";
+import { LinearProgress, Snackbar, Alert } from "@mui/material";
 
 export default function LoginForm() {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [errorMsg, setErrorMsg] = useState("");
+  const [snackbar, setSnackbar] = useState({ open: false, message: "", severity: "error" });
   const [loading, setLoading] = useState(false);
   const navigate = useNavigate();
 
@@ -23,9 +24,16 @@ export default function LoginForm() {
       navigate("/materias");
     } catch (error) {
       console.error("Erro no login:", error);
-      setErrorMsg(error.response?.data || "E-mail ou senha incorretos.");
+      const errorMessage = error.response?.data || "E-mail ou senha incorretos.";
+      setErrorMsg(errorMessage);
+      setSnackbar({ open: true, message: errorMessage, severity: "error" });
       setLoading(false);
     }
+  };
+
+  const handleCloseSnackbar = (event, reason) => {
+    if (reason === 'clickaway') return;
+    setSnackbar({ ...snackbar, open: false });
   };
 
   return (
@@ -45,7 +53,6 @@ export default function LoginForm() {
         />
       )}
       <form onSubmit={handleLogin} className={style.form}>
-      {errorMsg && <p className={style.errorMessage}>{errorMsg}</p>}
       <div className={style.formGroup}>
         <label htmlFor="email">E-mail</label>
         <input
@@ -74,6 +81,17 @@ export default function LoginForm() {
         {loading ? "Entrando..." : "Entrar"}
       </button>
     </form>
+
+    <Snackbar
+      open={snackbar.open}
+      autoHideDuration={4000}
+      onClose={handleCloseSnackbar}
+      anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+    >
+      <Alert onClose={handleCloseSnackbar} severity={snackbar.severity} sx={{ width: '100%', fontSize: '1rem', alignItems: 'center' }}>
+        {snackbar.message}
+      </Alert>
+    </Snackbar>
     </>
   );
 }

--- a/src/features/auth/pages/RecoverPasswordPage/RecoverPasswordPage.jsx
+++ b/src/features/auth/pages/RecoverPasswordPage/RecoverPasswordPage.jsx
@@ -1,6 +1,7 @@
 import style from "./RecoverPasswordPage.module.css";
 import { Link, useNavigate } from "react-router-dom";
 import { useState } from "react";
+import { Snackbar, Alert } from "@mui/material";
 import { forgotPassword, resetPassword } from "../../services/authService";
 import logoDark from "../../../../assets/logo-dark.png";
 
@@ -9,23 +10,20 @@ export default function RecoverPasswordPage() {
   const [email, setEmail] = useState("");
   const [code, setCode] = useState("");
   const [newPassword, setNewPassword] = useState("");
-  const [message, setMessage] = useState("");
-  const [error, setError] = useState("");
+  const [snackbar, setSnackbar] = useState({ open: false, message: "", severity: "success" });
   const [loading, setLoading] = useState(false);
   const navigate = useNavigate();
 
   const handleRequestRecovery = async (e) => {
     e.preventDefault();
     setLoading(true);
-    setMessage("");
-    setError("");
 
     try {
       await forgotPassword(email);
-      setMessage("Se este e-mail estiver cadastrado, um código de recuperação foi enviado.");
+      setSnackbar({ open: true, message: "Se este e-mail estiver cadastrado, um código de recuperação foi enviado.", severity: "success" });
       setStep(2);
     } catch (err) {
-      setError("Erro ao solicitar recuperação de senha.");
+      setSnackbar({ open: true, message: "Erro ao solicitar recuperação de senha.", severity: "error" });
     } finally {
       setLoading(false);
     }
@@ -34,18 +32,21 @@ export default function RecoverPasswordPage() {
   const handleResetPassword = async (e) => {
     e.preventDefault();
     setLoading(true);
-    setMessage("");
-    setError("");
 
     try {
       await resetPassword(email, code, newPassword);
-      setMessage("Senha redefinida com sucesso!");
+      setSnackbar({ open: true, message: "Senha redefinida com sucesso!", severity: "success" });
       setTimeout(() => navigate("/login"), 3000);
     } catch (err) {
-      setError(err?.response?.data || "Código inválido, expirado ou erro no servidor.");
+      setSnackbar({ open: true, message: err?.response?.data || "Código inválido, expirado ou erro no servidor.", severity: "error" });
     } finally {
       setLoading(false);
     }
+  };
+
+  const handleCloseSnackbar = (event, reason) => {
+    if (reason === 'clickaway') return;
+    setSnackbar({ ...snackbar, open: false });
   };
 
   return (
@@ -53,9 +54,6 @@ export default function RecoverPasswordPage() {
       <img src={logoDark} alt="StudyFlow Logo" className={style.logo} />
       <div className={style.recoverContainer}>
         <h2>Recuperação de Senha</h2>
-
-        {message && <p className={style.successMessage}>{message}</p>}
-        {error && <p className={style.errorMessage}>{error}</p>}
 
         {step === 1 ? (
           <>
@@ -119,6 +117,17 @@ export default function RecoverPasswordPage() {
 
         <p className={style.backText}>Lembrou a senha? <Link to={"/login"} className={style.link}>Voltar ao Login</Link></p>
       </div>
+
+      <Snackbar
+        open={snackbar.open}
+        autoHideDuration={4000}
+        onClose={handleCloseSnackbar}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+      >
+        <Alert onClose={handleCloseSnackbar} severity={snackbar.severity} sx={{ width: '100%', fontSize: '1rem', alignItems: 'center' }}>
+          {snackbar.message}
+        </Alert>
+      </Snackbar>
     </div>
   );
 }


### PR DESCRIPTION
Padroniza o feedback de erros e sucesso da aplicação utilizando o componente Snackbar do Material UI em todos os formulários.

Alterações:

- Removidas as mensagens de erro inline do LoginForm e RecoverPasswordPage
- Adicionado estado snackbar nos componentes AccountPage, LoginForm e RecoverPasswordPage
- Implementado handleCloseSnackbar em todos os formulários, ignorando fechamento por clickaway
- Feedbacks de sucesso e erro agora exibidos via Snackbar centralizado na parte inferior da tela com duração de 4 segundos

Impacto: login, recuperação de senha e edição de conta